### PR TITLE
allow for higher plug versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule SimpleTokenAuthentication.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:plug, "~> 1.3"},
+      {:plug, ">= 1.3"},
       {:credo, "~> 0.4.12", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]


### PR DESCRIPTION
In trying to use this with Phoenix 1.3, I'm getting the error
![image](https://user-images.githubusercontent.com/3421625/46232082-367d6e00-c32b-11e8-9904-df8e0a69fc61.png)

We should allow for higher versions of plug to be used.