### PR TITLE
Fix for empty string token.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+*.iml
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,3 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-*.iml
-.idea

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.4.2
+elixir 1.7.3

--- a/README.md
+++ b/README.md
@@ -23,22 +23,22 @@
 
   1. Add `simple_token_authentication` to your list of dependencies in `mix.exs`:
 
-    ```elixir
-    def deps do
-      [{:simple_token_authentication, "~> 0.1.0"}]
-    end
-    ```
+  ```elixir
+  def deps do
+    [{:simple_token_authentication, "~> 0.1.0"}]
+  end
+  ```
 
   2. Ensure `simple_token_authentication` is started before your application:
 
-    ```elixir
-    def application do
-      [applications: [:simple_token_authentication]]
-    end
-    ```
+  ```elixir
+  def application do
+    [applications: [:simple_token_authentication]]
+  end
+  ```
 
   3. Configure your token in `config.exs`:
-    ```elixir
-    config :simple_token_authentication, token: "your-token-here"
-    ```
+  ```elixir
+  config :simple_token_authentication, token: "your-token-here"
+  ```
 

--- a/lib/simple_token_authentication.ex
+++ b/lib/simple_token_authentication.ex
@@ -12,7 +12,7 @@ defmodule SimpleTokenAuthentication do
 
     val = get_auth_header(conn)
 
-    if token && val == token do
+    if token && String.trim(token) != "" && val == token do
       conn
     else
       conn

--- a/mix.exs
+++ b/mix.exs
@@ -7,11 +7,11 @@ defmodule SimpleTokenAuthentication.Mixfile do
     [app: :simple_token_authentication,
      version: @version,
      elixir: "~> 1.4",
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application
@@ -40,7 +40,7 @@ defmodule SimpleTokenAuthentication.Mixfile do
 
   defp description do
     """
-		A plug that checks for presence of a simple token for authentication
+		  A plug that checks for presence of a simple token for authentication
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,17 +1,19 @@
 defmodule SimpleTokenAuthentication.Mixfile do
   use Mix.Project
 
-	@version "0.2.0"
+  @version "0.2.0"
 
   def project do
-    [app: :simple_token_authentication,
-     version: @version,
-     elixir: "~> 1.4",
-     description: description(),
-     package: package(),
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps()]
+    [
+      app: :simple_token_authentication,
+      version: @version,
+      elixir: "~> 1.4",
+      description: description(),
+      package: package(),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application
@@ -40,13 +42,13 @@ defmodule SimpleTokenAuthentication.Mixfile do
 
   defp description do
     """
-		  A plug that checks for presence of a simple token for authentication
+    A plug that checks for presence of a simple token for authentication
     """
   end
 
   defp package do
     [
-      files: ["lib", "mix.exs",  "README*"],
+      files: ["lib", "mix.exs", "README*"],
       maintainers: ["Travis Elnicky", "Dhiman Swadia", "Arthur Weagel"],
       licenses: ["MIT"],
       links: %{

--- a/test/simple_token_authentication_test.exs
+++ b/test/simple_token_authentication_test.exs
@@ -27,6 +27,24 @@ defmodule SimpleTokenAuthenticationTest do
 		end
 	end
 
+  describe "empty token" do
+    test "returns a 401 status code" do
+      with_token("") do
+        # Create a test connection
+        conn =
+          :get
+          |> conn("/foo")
+          |> put_req_header("authorization", "")
+
+        # Invoke the plug
+        conn = SimpleTokenAuthentication.call(conn, @opts)
+
+        # Assert the response and status
+        assert conn.status == 401
+      end
+    end
+  end
+
   describe "with an invalid token" do
 		test "returns a 401 status code" do
       with_token("fake_token") do


### PR DESCRIPTION
 This can happen when the config is pulling form a `System.get_env` and the variable is present, but not set: 
```elixir
config :simple_token_authentication, token: System.get_env("TOKEN")
```
```bash
export TOKEN=
```

The request will also have to have the authorization header field with no value: 
```
curl -X GET \
  http://127.0.0.1:5500/api/v2/locations/1/reviews \
  -H 'authorization: ' \
  -H 'cache-control: no-cache'```