### PR TITLE
Change support to elixir 1.14 minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        elixir_version: [1.14, 1.15, 1.16, 1.17]
+        elixir_version: [1.15, 1.16, 1.17]
         otp_version: [ 25, 26, 27]
         exclude:
-          - otp_version: 26
-            elixir_version: 1.14
-          - otp_version: 27
-            elixir_version: 1.14
           - otp_version: 27
             elixir_version: 1.15
           - otp_version: 27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         elixir_version: [1.15, 1.16, 1.17]
-        otp_version: [ 25, 26, 27]
+        otp_version: [25, 26, 27]
         exclude:
           - otp_version: 27
             elixir_version: 1.15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
-        elixir_version: [1.12.3, 1.13.3, 1.14.1]
-        otp_version: [24, 25]
+        os: [ubuntu-22.04]
+        elixir_version: [1.14, 1.15, 1.16, 1.17]
+        otp_version: [ 25, 26, 27]
         exclude:
-          - otp_version: 25
-            elixir_version: 1.12.3
+          - otp_version: 26
+            elixir_version: 1.14
+          - otp_version: 27
+            elixir_version: 1.14
+          - otp_version: 27
+            elixir_version: 1.15
+          - otp_version: 27
+            elixir_version: 1.16
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ## [0.8.0] (2024-10-01)
-
+### Changed
 * Remove support for Elixir 1.11, 1.12 and 1.13. Minimum is Elixir 1.14
 
 ## [0.7.0] (2022-11-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.7.0] (2024-10-01)
+
+* Remove support for Elixir 1.11, 1.12 and 1.13. Minimum is Elixir 1.14
+
 ## [0.7.0] (2022-11-28)
 ### Changed
  * Upgrade dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 
-## [0.7.0] (2024-10-01)
+## [0.8.0] (2024-10-01)
 
 * Remove support for Elixir 1.11, 1.12 and 1.13. Minimum is Elixir 1.14
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,13 +2,13 @@ defmodule SimpleTokenAuthentication.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/podium/simple_token_authentication"
-  @version "0.7.0"
+  @version "0.8.0"
 
   def project do
     [
       app: :simple_token_authentication,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.14",
       description: "A plug that checks for presence of a simple token for authentication",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
per coming up deprecation policy, 1.13 will soon be retired to minimum is now 1.14 https://hexdocs.pm/elixir/compatibility-and-deprecations.html